### PR TITLE
Added an offline_data_stream attribute to the DetectorConfig definiti…

### DIFF
--- a/schema/confmodel/dunedaq.schema.xml
+++ b/schema/confmodel/dunedaq.schema.xml
@@ -164,6 +164,7 @@
   <attribute name="tpg_channel_map" description="Trigger Primitive channel map" type="string" init-value="PD2HDChannelMap" is-not-null="yes"/>
   <attribute name="clock_speed_hz" type="u32" init-value="62500000" is-not-null="yes"/>
   <attribute name="op_env" description="Operational environment " type="string" init-value="swtest" is-not-null="yes"/>
+  <attribute name="offline_data_stream" description="The data stream value that we send to offline." type="string" init-value="cosmics" is-not-null="yes"/>
  </class>
 
  <class name="DetectorStream">


### PR DESCRIPTION
…on.  This is to allow us to specify this parameter in our configurations (so that it gets passed to Offline in the file-transfer metadata).

This change is part of a wider set that includes one in dfmodules ([PR 383](https://github.com/DUNE-DAQ/dfmodules/pull/383)) and can generally be described as porting HDF5 Attribute changes from v4 to v5.