### PR TITLE
Revert "Remove the `--name` and `--session` from the DAQ app CLI, and use env instead"

### DIFF
--- a/include/confmodel/util.hpp
+++ b/include/confmodel/util.hpp
@@ -109,6 +109,10 @@ const std::vector<std::string> construct_commandline_parameters_appfwk(
   const std::string configuration_uri = confdb.get_impl_spec();
 
   return {
+      "-s",
+      session->UID(),
+      "--name",
+      app->UID(),
       "-c",
       control_uri,
       "--configurationService",


### PR DESCRIPTION
Reverts DUNE-DAQ/confmodel#45

So that thread pinning can use the name and session.