### PR TITLE
Add a configurable log path to the session and application

### DIFF
--- a/schema/confmodel/dunedaq.schema.xml
+++ b/schema/confmodel/dunedaq.schema.xml
@@ -91,6 +91,7 @@
  <class name="Application" description="A software executable" is-abstract="yes">
   <attribute name="application_name" description="Name of the application binary to run." type="string" is-not-null="yes"/>
   <attribute name="commandline_parameters" description="command line parameters to add when starting the application" type="string" is-multi-value="yes"/>
+  <attribute name="log_path" description="Where the applications, controllers and infrastructure applications stdout/err go. This take precedence over the Session's log_path. If none of them is set, PWD is used." type="string" is-not-null="no"/>
   <relationship name="application_environment" description="Define process environment for this application." class-type="VariableBase" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="runs_on" description="VirtualHost to run this application on" class-type="VirtualHost" low-cc="one" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
   <relationship name="exposes_service" description="Services exposed i.e. provided by this application" class-type="Service" low-cc="zero" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
@@ -366,6 +367,7 @@
   <relationship name="infrastructure_applications" class-type="Application" low-cc="zero" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
   <relationship name="detector_configuration" class-type="DetectorConfig" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="opmon_uri" description="Configuration for the OpMon facilities used across the session" class-type="OpMonURI" low-cc="one" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
+  <attribute name="log_path" description="Where the applications, controllers and infrastructure applications stdout/err go. This is overwritten by the Application's log_path. If none of them is set, PWD is used." type="string" is-not-null="no"/>
   <method name="get_all_applications" description="Returns applications defined in the Session and all of its Segments.">
    <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::Application *&gt; get_all_applications() const" body=""/>
   </method>


### PR DESCRIPTION
Add an optional `log_path` attribute to the Session and Application schemas.
The way this is intended to be used by the run control is the following:
1. Applications will log to their `log_path` (defined in the `Application` schema).
2. If above is not set, the applications will log to their `Session`'s `log_path`.
3. If above are not set, the applications will log to `PWD`.

# To test

I've had to basically check out the whole of the DAQ, otherwise one gets exception thrown by the application. Here is the list of repos I used (!) :
```
git clone git@github.com:DUNE-DAQ/appfwk
git clone git@github.com:DUNE-DAQ/appmodel
git clone git@github.com:DUNE-DAQ/confmodel -b plasorak/configurable-log-paths
git clone git@github.com:DUNE-DAQ/daqsystemtest -b plasorak/configurable-log-paths
git clone git@github.com:DUNE-DAQ/datahandlinglibs
git clone git@github.com:DUNE-DAQ/dfmodules
git clone git@github.com:DUNE-DAQ/fdreadoutlibs
git clone git@github.com:DUNE-DAQ/fdreadoutmodules
git clone git@github.com:DUNE-DAQ/hdf5libs
git clone git@github.com:DUNE-DAQ/hsilibs
git clone git@github.com:DUNE-DAQ/iomanager
git clone git@github.com:DUNE-DAQ/oksconflibs
git clone git@github.com:DUNE-DAQ/opmonlib
git clone git@github.com:DUNE-DAQ/timing
git clone git@github.com:DUNE-DAQ/timinglibs
git clone git@github.com:DUNE-DAQ/trigger
```

and drunc:

```
git clone git@github.com:DUNE-DAQ/drunc -b plasorak/configurable-log-paths
```

Then, add, in `daqsystemtest/config/daqsystemtest/example-configs.data.xml`'s `local-1x1-config` Session:
```xml
<obj class="Session" id="ehn1-local-1x1-config">
 <attr name="data_request_timeout_ms" type="u32" val="1000"/>
 <attr name="log_path" type="string" val="/somewhere/writable"/> <!-- add this -->
 <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
 <attr name="controller_log_level" type="enum" val="INFO"/>
 <attr name="log_path" type="string" val="/log"/>
 <rel name="connectivity_service" class="ConnectivityService" id="ehn1-connectivity-service-config"/>
 <rel name="environment">
  <ref class="VariableSet" id="ehn1-variables"/>
 </rel>
 <rel name="disabled">
  <ref class="DFApplication" id="df-02"/>
  <ref class="DFApplication" id="df-03"/>
  <ref class="ReadoutApplication" id="ru-02"/>
 </rel>
 <rel name="segment" class="Segment" id="root-segment"/>
 <rel name="detector_configuration" class="DetectorConfig" id="dummy-detector"/>
 <rel name="opmon_uri" class="OpMonURI" id="cern-opmon-uri"/>
</obj>
```

and change it for an application (say `"hsi-to-tc-app`, in `daqsystemtest/config/daqsystemtest/hsi-segment.data.xml`:

```xml
<obj class="HSIEventToTCApplication" id="hsi-to-tc-app">
<attr name="log_path" type="string" val="/somewhere/else/writable"/> <!-- add this-->
 <attr name="application_name" type="string" val="daq_application"/>
 <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
 <rel name="exposes_service">
  <ref class="Service" id="dataRequests"/>
  <ref class="Service" id="HSIEvents"/>
  <ref class="Service" id="hsi-to-tc-app_control"/>
 </rel>
 <rel name="opmon_conf" class="OpMonConf" id="slow-all-monitoring"/>
 <rel name="source_id" class="SourceIDConf" id="hsi-tc-srcid-1"/>
 <rel name="network_rules">
  <ref class="NetworkConnectionRule" id="hsi-rule"/>
  <ref class="NetworkConnectionRule" id="tc-net-rule"/>
 </rel>
 <rel name="hsevent_to_tc_conf" class="HSI2TCTranslatorConf" id="hsi-to-tc-conf"/>
</obj>
```

Boot the applications, and check that all the logs are in `/somewhere/writable` (controller, connectivity server, and daq_app) except the `hsi-to-tc-app` logs which should be in `/somewhere/else/writable`.
