### PR TITLE
Simpler control service

### DIFF
--- a/include/confmodel/util.hpp
+++ b/include/confmodel/util.hpp
@@ -29,7 +29,7 @@ ERS_DECLARE_ISSUE_BASE(
 ERS_DECLARE_ISSUE_BASE(
     confmodel, NoControlServiceDefined, ConfigurationError,
     "The control service has not been set up for the application " + app_name +
-        " you need to define a service called which has a name finishing with \'control\'",
+        " you need to define a service called which has a name finishing with \'_control\'",
     , ((std::string)app_name)
 )
 
@@ -103,7 +103,7 @@ const std::vector<std::string> construct_commandline_parameters_appfwk(
   const dunedaq::confmodel::Service *control_service = nullptr;
 
   for (auto const *as : app->get_exposes_service()) {
-    if (as->UID().ends_with("control")) {
+    if (as->UID().ends_with("_control")) {
       if (control_service)
         throw DuplicatedControlService(ERS_HERE, as->UID());
       control_service = as;

--- a/include/confmodel/util.hpp
+++ b/include/confmodel/util.hpp
@@ -29,10 +29,19 @@ ERS_DECLARE_ISSUE_BASE(
 ERS_DECLARE_ISSUE_BASE(
     confmodel, NoControlServiceDefined, ConfigurationError,
     "The control service has not been set up for the application " + app_name +
-        " you need to define a service called " + app_name + "_control",
+        " you need to define a service called which has a name finishing with \'control\'",
+    , ((std::string)app_name)
+)
+
+ERS_DECLARE_ISSUE_BASE(
+    confmodel, DuplicatedControlService, ConfigurationError,
+    "The control service has been defined multiple times for the application " +
+        app_name + " you need to define only one service called control",
     , ((std::string)app_name)
 
 )
+
+
 
 namespace confmodel {
 
@@ -93,10 +102,13 @@ const std::vector<std::string> construct_commandline_parameters_appfwk(
 
   const dunedaq::confmodel::Service *control_service = nullptr;
 
-  for (auto const *as : app->get_exposes_service())
-    if (as->UID() ==
-        app->UID() + "_control") // unclear this is the best way to do this.
+  for (auto const *as : app->get_exposes_service()) {
+    if (as->UID().ends_with("control")) {
+      if (control_service)
+        throw DuplicatedControlService(ERS_HERE, as->UID());
       control_service = as;
+    }
+  }
 
   if (control_service == nullptr)
     throw NoControlServiceDefined(ERS_HERE, app->UID());

--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -326,7 +326,7 @@ const std::vector<std::string> RCApplication::construct_commandline_parameters(
     const std::string controller_log_level = session->get_controller_log_level();
 
     for (auto const *as : get_exposes_service()) {
-      if (as->UID().ends_with("control")) {
+      if (as->UID().ends_with("_control")) {
         if (control_service)
           throw DuplicatedControlService(ERS_HERE, as->UID());
         control_service = as;

--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -325,9 +325,13 @@ const std::vector<std::string> RCApplication::construct_commandline_parameters(
 
     const std::string controller_log_level = session->get_controller_log_level();
 
-    for (auto const* as: get_exposes_service())
-      if (as->UID() == UID()+"_control") // unclear this is the best way to do this.
+    for (auto const *as : get_exposes_service()) {
+      if (as->UID().ends_with("control")) {
+        if (control_service)
+          throw DuplicatedControlService(ERS_HERE, as->UID());
         control_service = as;
+      }
+    }
 
     if (control_service == nullptr)
       throw NoControlServiceDefined(ERS_HERE, UID());
@@ -358,7 +362,7 @@ std::vector<const confmodel::DetDataSender*> DetectorToDaqConnection::get_sender
           senders.push_back(sender);
       }
       else {
-          // Look for a resource set containing senders 
+          // Look for a resource set containing senders
           auto rs = d2d_res->cast<confmodel::ResourceSet>();
           if (rs != nullptr) {
               // Look for senders in resource set
@@ -382,7 +386,7 @@ const confmodel::DetDataReceiver* DetectorToDaqConnection::get_receiver() const 
 
   for ( auto d2d_res : this->get_contains() ) {
       auto r = d2d_res->cast<confmodel::DetDataReceiver>();
-      if ( r == nullptr ) 
+      if ( r == nullptr )
         continue;
 
       receivers.push_back(r);
@@ -409,7 +413,7 @@ std::vector<const confmodel::DetectorStream*> DetectorToDaqConnection::get_strea
         if ( !stream ) {
           throw(ConfigurationError(ERS_HERE, "DetectorToDaqConnection : Non-stream object '"+stream_res->UID()+"' found in DetDataSender '"+stream_res->UID()+"'"));
         }
-        
+
         streams.push_back(stream->cast<confmodel::DetectorStream>());
       }
     }
@@ -420,15 +424,15 @@ std::vector<const confmodel::DetectorStream*> DetectorToDaqConnection::get_strea
 std::string OpMonURI::get_URI( const std::string & app ) const {
 
   auto type = get_type();
-  if ( type == "file" ) { 
+  if ( type == "file" ) {
     return type + "://" + get_path();
   }
-  
+
   if ( type == "stream" ) {
     return type + "://" + get_path();
   }
-  
-  return "stdout://";  
+
+  return "stdout://";
 }
 
 }


### PR DESCRIPTION
With this PR, the "control_service" become a bit simpler in the configuration: there is no need to have a "control_service" for each app, a single control service can be created for all the DAQ apps and drunc controllers.

Example in `daqsystemtest` to follow.