### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc3 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,28 +15,22 @@ find_package(nlohmann_json REQUIRED)
 #find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 ##############################################################################
-include_directories(${CMAKE_BINARY_DIR}/confmodel)
-daq_oks_codegen(dunedaq.schema.xml)
 
-daq_add_library(dalMethods.cpp
-  test_circular_dependency.cpp disabled-components.cpp
-  LINK_LIBRARIES conffwk::conffwk okssystem::okssystem
-  logging::logging nlohmann_json::nlohmann_json)
-
+daq_add_dal_library(dunedaq.schema.xml SOURCES dalMethods.cpp test_circular_dependency.cpp disabled-components.cpp LINK_LIBRARIES okssystem::okssystem logging::logging nlohmann_json::nlohmann_json)
 
 daq_add_application(listApps list_apps.cxx
-  LINK_LIBRARIES confmodel conffwk::conffwk)
+  LINK_LIBRARIES confmodel_dal conffwk::conffwk)
 
 daq_add_application(disable_test disable_test.cxx TEST
-  LINK_LIBRARIES confmodel conffwk::conffwk logging::logging)
+  LINK_LIBRARIES confmodel_dal conffwk::conffwk logging::logging)
 
 daq_add_application(jsonable_test jsonable_test.cxx TEST
-  LINK_LIBRARIES confmodel conffwk::conffwk logging::logging)
+  LINK_LIBRARIES confmodel_dal conffwk::conffwk logging::logging)
 ##############################################################################
 
 
 # See https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/#daq_add_python_bindings
-daq_add_python_bindings(*.cpp LINK_LIBRARIES confmodel)
+daq_add_python_bindings(*.cpp LINK_LIBRARIES confmodel_dal)
 
 
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(confmodel VERSION 2.3.0)
+project(confmodel VERSION 2.4.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/cmake/confmodelConfig.cmake.in
+++ b/cmake/confmodelConfig.cmake.in
@@ -16,7 +16,11 @@ find_package(nlohmann_json)
 if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
-add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
+
+add_library(@PROJECT_NAME@::@PROJECT_NAME@_dal ALIAS @PROJECT_NAME@_dal)
+
+add_library(@PROJECT_NAME@::dal            ALIAS @PROJECT_NAME@_dal)
+add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@_dal)
 
 get_filename_component(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 
@@ -25,6 +29,9 @@ else()
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
+
+add_library(@PROJECT_NAME@::dal            ALIAS @PROJECT_NAME@::@PROJECT_NAME@_dal)
+add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@::@PROJECT_NAME@_dal)
 
 set(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_DIR}/../../../share")
 


### PR DESCRIPTION
This PR is part of an overall merging of the `patch/fddaq-v5.3.x` branches into `develop` in the wake of release candidate 3 for `fddaq-v5.3.2`; note that the actual source branch, `johnfreeman/merge_fddaq-v5.3.2-rc3-a9_into_develop`, is an intermediary here. A test release was built with the source branch (`NFDT_DEV_250617_A9`) and successful integration tests were run (https://github.com/DUNE-DAQ/daq-release/actions/runs/15717205217). 