### PR TITLE
Gcrone/managed object

### DIFF
--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -39,9 +39,12 @@ namespace dunedaq::confmodel::python {
 
   std::set<std::string>
   segment_get_managed_object_tags(Configuration& db,
-                                  const std::string& segment_name,
-                                  const std::string& session_name) {
+                                  const std::string& session_name,
+                                  std::string segment_name="") {
     auto session=db.get<Session>(session_name);
+    if (segment_name == "") {
+      segment_name = session->get_segment()->UID();
+    }
     auto segment=db.get<Segment>(segment_name);
     return segment->managed_object_tags(session);
   }
@@ -185,7 +188,9 @@ register_dal_methods(py::module& m)
     .def_readonly("class_name", &ObjectLocator::class_name)
     ;
 
-  m.def("segment_get_managed_object_tags", &segment_get_managed_object_tags, "Get list of ALL enabled ManagedObject tags in the requested segment");
+  m.def("segment_get_managed_object_tags", &segment_get_managed_object_tags,
+        py::arg("db"), py::arg("session_name"), py::arg("segment_name")="",
+        "Get list of ALL enabled ManagedObject tags in the requested segment");
   m.def("session_get_all_applications", &session_get_all_applications, "Get list of ALL applications (regardless of enabled/disabled state) in the requested session");
   m.def("session_get_enabled_applications", &session_get_enabled_applications, "Get list of enabled applications in the requested session");
 

--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -224,7 +224,7 @@ register_dal_methods(py::module& m)
 
   m.def("segment_get_managed_object_tags", &segment_get_managed_object_tags,
         py::arg("db"), py::arg("session_name"), py::arg("segment_name")="",
-        "Get list of ALL enabled ManagedObject tags in the requested segment");
+        "Get list of ALL ManagedObject tags in the requested segment that are enabled in the given session. If only a session is specified then the segment will be taken from the session's segment relationship");
   m.def("session_get_all_applications", &session_get_all_applications, "Get list of ALL applications (regardless of enabled/disabled state) in the requested session");
   m.def("session_get_enabled_applications", &session_get_enabled_applications, "Get list of enabled applications in the requested session");
 

--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -18,6 +18,7 @@
 #include "confmodel/DetDataSender.hpp"
 #include "confmodel/HostComponent.hpp"
 #include "confmodel/RCApplication.hpp"
+#include "confmodel/Segment.hpp"
 #include "confmodel/Session.hpp"
 
 
@@ -37,10 +38,12 @@ namespace dunedaq::confmodel::python {
   };
 
   std::set<std::string>
-  session_get_managed_object_tags(Configuration& db,
-                               const std::string& session_name) {
+  segment_get_managed_object_tags(Configuration& db,
+                                  const std::string& segment_name,
+                                  const std::string& session_name) {
     auto session=db.get<Session>(session_name);
-    return session->managed_object_tags();
+    auto segment=db.get<Segment>(segment_name);
+    return segment->managed_object_tags(session);
   }
 
   std::vector<ObjectLocator>
@@ -182,7 +185,7 @@ register_dal_methods(py::module& m)
     .def_readonly("class_name", &ObjectLocator::class_name)
     ;
 
-  m.def("session_get_managed_object_tags", &session_get_managed_object_tags, "Get list of ALL enabled ManagedObject tags in the requested session");
+  m.def("segment_get_managed_object_tags", &segment_get_managed_object_tags, "Get list of ALL enabled ManagedObject tags in the requested segment");
   m.def("session_get_all_applications", &session_get_all_applications, "Get list of ALL applications (regardless of enabled/disabled state) in the requested session");
   m.def("session_get_enabled_applications", &session_get_enabled_applications, "Get list of enabled applications in the requested session");
 

--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -36,6 +36,12 @@ namespace dunedaq::confmodel::python {
     const std::string class_name;
   };
 
+  std::set<std::string>
+  session_get_managed_object_tags(Configuration& db,
+                               const std::string& session_name) {
+    auto session=db.get<Session>(session_name);
+    return session->managed_object_tags();
+  }
 
   std::vector<ObjectLocator>
   session_get_all_applications(Configuration& db,
@@ -176,6 +182,7 @@ register_dal_methods(py::module& m)
     .def_readonly("class_name", &ObjectLocator::class_name)
     ;
 
+  m.def("session_get_managed_object_tags", &session_get_managed_object_tags, "Get list of ALL enabled ManagedObject tags in the requested session");
   m.def("session_get_all_applications", &session_get_all_applications, "Get list of ALL applications (regardless of enabled/disabled state) in the requested session");
   m.def("session_get_enabled_applications", &session_get_enabled_applications, "Get list of enabled applications in the requested session");
 

--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -21,7 +21,8 @@
 #include "confmodel/Segment.hpp"
 #include "confmodel/Session.hpp"
 
-
+#include <format>
+#include <stdexcept>
 #include <sstream>
 
 namespace py = pybind11;
@@ -42,10 +43,16 @@ namespace dunedaq::confmodel::python {
                                   const std::string& session_name,
                                   std::string segment_name="") {
     auto session=db.get<Session>(session_name);
+    if (session == nullptr) {
+      throw (std::runtime_error(std::format("Session {} not found", session_name)));
+    }
     if (segment_name == "") {
       segment_name = session->get_segment()->UID();
     }
     auto segment=db.get<Segment>(segment_name);
+    if (segment == nullptr) {
+      throw (std::runtime_error(std::format("Segment {} not found", segment_name)));
+    }
     return segment->managed_object_tags(session);
   }
 
@@ -53,6 +60,9 @@ namespace dunedaq::confmodel::python {
   session_get_all_applications(Configuration& db,
                                const std::string& session_name) {
     auto session=db.get<Session>(session_name);
+    if (session == nullptr) {
+      throw (std::runtime_error(std::format("Session {} not found", session_name)));
+    }
     std::vector<ObjectLocator> apps;
     for (auto app : session->all_applications()) {
       apps.push_back({app->UID(),app->class_name()});
@@ -64,6 +74,9 @@ namespace dunedaq::confmodel::python {
   session_get_enabled_applications(Configuration& db,
                                    const std::string& session_name) {
     auto session=db.get<Session>(session_name);
+    if (session == nullptr) {
+      throw (std::runtime_error(std::format("Session {} not found", session_name)));
+    }
     std::vector<ObjectLocator> apps;
     for (auto app : session->enabled_applications()) {
       apps.push_back({app->UID(),app->class_name()});
@@ -75,6 +88,9 @@ namespace dunedaq::confmodel::python {
                           const std::string& session_id,
                           const std::string& component_id) {
     const dunedaq::confmodel::Session* session_ptr = db.get<dunedaq::confmodel::Session>(session_id);
+    if (session_ptr == nullptr) {
+      throw (std::runtime_error(std::format("Session {} not found", session_id)));
+    }
     const dunedaq::confmodel::Resource* component_ptr = db.get<dunedaq::confmodel::Resource>(component_id);
     if (component_ptr == nullptr) {
       return false;
@@ -87,6 +103,9 @@ namespace dunedaq::confmodel::python {
                                                                 const std::string& session_id,
                                                                 const std::string& component_id) {
     const dunedaq::confmodel::Session* session_ptr = db.get<dunedaq::confmodel::Session>(session_id);
+    if (session_ptr == nullptr) {
+      throw (std::runtime_error(std::format("Session {} not found", session_id)));
+    }
     const dunedaq::confmodel::Resource* component_ptr = db.get<dunedaq::confmodel::Resource>(component_id);
 
     std::list<std::vector<const dunedaq::confmodel::Resource*>> parents;
@@ -108,6 +127,9 @@ namespace dunedaq::confmodel::python {
 
   std::vector<std::string> daq_application_get_used_hostresources(Configuration& db, const std::string& app_id) {
     auto app = db.get<dunedaq::confmodel::DaqApplication>(app_id);
+    if (app == nullptr) {
+      throw (std::runtime_error(std::format("DaqApplication {} not found", app_id)));
+    }
     std::vector<std::string> resources;
     for (auto res : app->get_used_hostresources()) {
       resources.push_back(res->UID());
@@ -119,7 +141,13 @@ namespace dunedaq::confmodel::python {
                                                                             const std::string& session_id,
                                                                             const std::string& app_id) {
     const auto* app = db.get<dunedaq::confmodel::DaqApplication>(app_id);
+    if (app == nullptr) {
+      throw (std::runtime_error(std::format("DaqApplication {} not found", app_id)));
+    }
     const auto* session = db.get<dunedaq::confmodel::Session>(session_id);
+    if (session == nullptr) {
+      throw (std::runtime_error(std::format("Session {} not found", session_id)));
+    }
     return app->construct_commandline_parameters(db, session);
   }
 
@@ -127,7 +155,13 @@ namespace dunedaq::confmodel::python {
                                                                            const std::string& session_id,
                                                                            const std::string& app_id) {
     const auto* app = const_cast<Configuration&>(db).get<dunedaq::confmodel::RCApplication>(app_id);
+    if (app == nullptr) {
+      throw (std::runtime_error(std::format("RCApplication {} not found", app_id)));
+    }
     const auto* session = const_cast<Configuration&>(db).get<dunedaq::confmodel::Session>(session_id);
+    if (session == nullptr) {
+      throw (std::runtime_error(std::format("Session {} not found", session_id)));
+    }
     return app->construct_commandline_parameters(db, session);
   }
 

--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -22,8 +22,10 @@
 #include "confmodel/Session.hpp"
 
 #include <format>
+#include <set>
 #include <stdexcept>
 #include <sstream>
+#include <string>
 
 namespace py = pybind11;
 using namespace dunedaq::conffwk;

--- a/schema/confmodel/dunedaq.schema.xml
+++ b/schema/confmodel/dunedaq.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="49" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20250923T103939"/>
+<info name="" type="" num-of-items="51" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="mroda" last-modified-on="mroda-xpsp" last-modification-time="20260205T115614"/>
 
  <class name="ActionPlan" description="A set of steps for an application to carry out a command">
   <attribute name="execution_policy" description="How the application should dispatch the command to modules matched by each step of the ActionPlan" type="enum" range="modules-in-parallel,modules-in-series" init-value="modules-in-parallel"/>
@@ -179,6 +179,7 @@
 
  <class name="DetectorToDaqConnection" is-abstract="yes">
   <superclass name="ResourceSet"/>
+  <superclass name="ManagedComponent"/>
   <method name="streams" description="">
    <method-implementation language="c++" prototype="std::vector&lt;const confmodel::DetectorStream*&gt; streams() const" body=""/>
   </method>
@@ -255,6 +256,10 @@
   <attribute name="this" type="u32" init-value="0" is-not-null="yes"/>
   <attribute name="that" type="u32" init-value="1" is-not-null="yes"/>
   <relationship name="other" class-type="JsonableTest" low-cc="zero" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="ManagedComponent">
+  <attribute name="tag" description="if null, the check is disabled against the resource manager" type="string"/>
  </class>
 
  <class name="NetworkConnection">
@@ -340,6 +345,11 @@
   </method>
  </class>
 
+ <class name="ResourceManagerConf">
+  <attribute name="address" type="string" is-not-null="yes"/>
+  <attribute name="port" type="u16" is-not-null="yes"/>
+ </class>
+
  <class name="ResourceSet" description="Base class for a collection of Resource items. Derived classes must implement the contained_resources() method to return a vector of Resource objects." is-abstract="yes">
   <superclass name="Resource"/>
   <method name="contained_resources" description="Virtual method to obtain the list of all contained Resources. Used internally by the core disabled logic. Not intended to be used in application code as that should be using individual relationships of the derived classes.">
@@ -405,6 +415,7 @@
   <relationship name="infrastructure_applications" class-type="Application" low-cc="zero" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
   <relationship name="detector_configuration" class-type="DetectorConfig" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="opmon_uri" description="Configuration for the OpMon facilities used across the session" class-type="OpMonURI" low-cc="one" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
+  <relationship name="resource_manager" class-type="ResourceManagerConf" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="all_applications" description="Returns applications defined in the Session and all of its Segments.">
    <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::Application *&gt; all_applications() const" body="BEGIN_PRIVATE_SECTION&#xA;friend class DisabledResources;&#xA;std::vector&lt;const Application*&gt;getSegmentApps(const Segment*,bool)const;&#xA;END_PRIVATE_SECTION&#xA;&#xA;BEGIN_HEADER_PROLOGUE&#xA;namespace dunedaq::confmodel{class Segment;}&#xA;END_HEADER_PROLOGUE"/>
   </method>

--- a/schema/confmodel/dunedaq.schema.xml
+++ b/schema/confmodel/dunedaq.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="51" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="mroda" last-modified-on="mroda-xpsp" last-modification-time="20260205T115614"/>
+<info name="" type="" num-of-items="51" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260211T160631"/>
 
  <class name="ActionPlan" description="A set of steps for an application to carry out a command">
   <attribute name="execution_policy" description="How the application should dispatch the command to modules matched by each step of the ActionPlan" type="enum" range="modules-in-parallel,modules-in-series" init-value="modules-in-parallel"/>
@@ -179,7 +179,6 @@
 
  <class name="DetectorToDaqConnection" is-abstract="yes">
   <superclass name="ResourceSet"/>
-  <superclass name="ManagedComponent"/>
   <method name="streams" description="">
    <method-implementation language="c++" prototype="std::vector&lt;const confmodel::DetectorStream*&gt; streams() const" body=""/>
   </method>
@@ -258,8 +257,11 @@
   <relationship name="other" class-type="JsonableTest" low-cc="zero" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="no"/>
  </class>
 
- <class name="ManagedComponent">
-  <attribute name="tag" description="if null, the check is disabled against the resource manager" type="string"/>
+ <class name="ManagedObject">
+  <attribute name="tag" description="(Component of) name  to be matched with resource manager for locking" type="string" is-not-null="yes"/>
+  <method name="object_tags" description="Method to return strings to be submitted to resource maanger for reservation.">
+   <method-implementation language="c++" prototype="virtual std::vector&lt;std::string&gt; object_tags() const" body="return {get_tag()};"/>
+  </method>
  </class>
 
  <class name="NetworkConnection">
@@ -299,6 +301,7 @@
  </class>
 
  <class name="PhysicalHost">
+  <superclass name="ManagedObject"/>
   <relationship name="contains" description="List of hardware components on this host" class-type="HostComponent" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
  </class>
 
@@ -424,6 +427,9 @@
   </method>
   <method name="resource_root" description="">
    <method-implementation language="c++" prototype="const ResourceSet* resource_root() const override" body="return get_segment();"/>
+  </method>
+  <method name="managed_object_tags" description="Method to find all (enabled) managed objects in this session.">
+   <method-implementation language="c++" prototype="std::set&lt;std::string&gt; managed_object_tags() const" body="BEGIN_HEADER_PROLOGUE&#xA;#include &lt;map&gt;&#xA;#include &lt;string&gt;&#xA;#include &lt;vector&gt;&#xA;END_HEADER_PROLOGUE"/>
   </method>
  </class>
 

--- a/schema/confmodel/dunedaq.schema.xml
+++ b/schema/confmodel/dunedaq.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="51" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260217T094939"/>
+<info name="" type="" num-of-items="51" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260224T141634"/>
 
  <class name="ActionPlan" description="A set of steps for an application to carry out a command">
   <attribute name="execution_policy" description="How the application should dispatch the command to modules matched by each step of the ActionPlan" type="enum" range="modules-in-parallel,modules-in-series" init-value="modules-in-parallel"/>
@@ -152,8 +152,9 @@
   <attribute name="modules" type="class" is-multi-value="yes"/>
  </class>
 
- <class name="DetDataReceiver" is-abstract="yes">
+ <class name="DetDataReceiver" description="Abstract base class for detector data receivers" is-abstract="yes">
   <superclass name="Resource"/>
+  <superclass name="ManagedObject"/>
  </class>
 
  <class name="DetDataSender" is-abstract="yes">
@@ -258,8 +259,8 @@
   <relationship name="other" class-type="JsonableTest" low-cc="zero" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="no"/>
  </class>
 
- <class name="ManagedObject">
-  <attribute name="tag" description="(Component of) name  to be matched with resource manager for locking" type="string" is-not-null="yes"/>
+ <class name="ManagedObject" description="Abstract base class for an item that is managed by the Resource Manager." is-abstract="yes">
+  <attribute name="tag" description="(Component of) name  to be matched with resource manager for locking." type="string"/>
   <method name="object_tags" description="Method to return strings to be submitted to resource maanger for reservation.">
    <method-implementation language="c++" prototype="virtual std::set&lt;std::string&gt; object_tags() const" body="return {get_tag()};"/>
   </method>
@@ -302,7 +303,6 @@
  </class>
 
  <class name="PhysicalHost">
-  <superclass name="ManagedObject"/>
   <relationship name="contains" description="List of hardware components on this host" class-type="HostComponent" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
  </class>
 

--- a/schema/confmodel/dunedaq.schema.xml
+++ b/schema/confmodel/dunedaq.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="51" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260211T160631"/>
+<info name="" type="" num-of-items="51" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260216T121951"/>
 
  <class name="ActionPlan" description="A set of steps for an application to carry out a command">
   <attribute name="execution_policy" description="How the application should dispatch the command to modules matched by each step of the ActionPlan" type="enum" range="modules-in-parallel,modules-in-series" init-value="modules-in-parallel"/>
@@ -179,6 +179,7 @@
 
  <class name="DetectorToDaqConnection" is-abstract="yes">
   <superclass name="ResourceSet"/>
+  <superclass name="ManagedObject"/>
   <method name="streams" description="">
    <method-implementation language="c++" prototype="std::vector&lt;const confmodel::DetectorStream*&gt; streams() const" body=""/>
   </method>
@@ -260,7 +261,7 @@
  <class name="ManagedObject">
   <attribute name="tag" description="(Component of) name  to be matched with resource manager for locking" type="string" is-not-null="yes"/>
   <method name="object_tags" description="Method to return strings to be submitted to resource maanger for reservation.">
-   <method-implementation language="c++" prototype="virtual std::vector&lt;std::string&gt; object_tags() const" body="return {get_tag()};"/>
+   <method-implementation language="c++" prototype="virtual std::set&lt;std::string&gt; object_tags() const" body="return {get_tag()};"/>
   </method>
  </class>
 
@@ -395,6 +396,9 @@
   <method name="compute_disabled_state" description="">
    <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body=""/>
   </method>
+  <method name="managed_object_tags" description="Method to find all (enabled) managed objects in this session.">
+   <method-implementation language="c++" prototype="std::set&lt;std::string&gt; managed_object_tags(const Session*) const" body="BEGIN_HEADER_PROLOGUE&#xA;#include &lt;map&gt;&#xA;#include &lt;string&gt;&#xA;#include &lt;vector&gt;&#xA;&#xA;namespace dunedaq::confmodel {&#xA; class Session;&#xA;}&#xA;END_HEADER_PROLOGUE"/>
+  </method>
  </class>
 
  <class name="Service">
@@ -427,9 +431,6 @@
   </method>
   <method name="resource_root" description="">
    <method-implementation language="c++" prototype="const ResourceSet* resource_root() const override" body="return get_segment();"/>
-  </method>
-  <method name="managed_object_tags" description="Method to find all (enabled) managed objects in this session.">
-   <method-implementation language="c++" prototype="std::set&lt;std::string&gt; managed_object_tags() const" body="BEGIN_HEADER_PROLOGUE&#xA;#include &lt;map&gt;&#xA;#include &lt;string&gt;&#xA;#include &lt;vector&gt;&#xA;END_HEADER_PROLOGUE"/>
   </method>
  </class>
 

--- a/schema/confmodel/dunedaq.schema.xml
+++ b/schema/confmodel/dunedaq.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="51" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260216T121951"/>
+<info name="" type="" num-of-items="51" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260217T094939"/>
 
  <class name="ActionPlan" description="A set of steps for an application to carry out a command">
   <attribute name="execution_policy" description="How the application should dispatch the command to modules matched by each step of the ActionPlan" type="enum" range="modules-in-parallel,modules-in-series" init-value="modules-in-parallel"/>
@@ -396,7 +396,7 @@
   <method name="compute_disabled_state" description="">
    <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body=""/>
   </method>
-  <method name="managed_object_tags" description="Method to find all (enabled) managed objects in this session.">
+  <method name="managed_object_tags" description="Method to find all managed objects in this segment that are enabled in the given session.">
    <method-implementation language="c++" prototype="std::set&lt;std::string&gt; managed_object_tags(const Session*) const" body="BEGIN_HEADER_PROLOGUE&#xA;#include &lt;map&gt;&#xA;#include &lt;string&gt;&#xA;#include &lt;vector&gt;&#xA;&#xA;namespace dunedaq::confmodel {&#xA; class Session;&#xA;}&#xA;END_HEADER_PROLOGUE"/>
   </method>
  </class>

--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -234,9 +234,13 @@ relationships(conffwk::Configuration& confdb, ConfigObject& obj) {
   return result;
 }
 std::set<std::string>
-Session::managed_object_tags() const {
+Segment::managed_object_tags(const Session* session) const {
   std::set<std::string> related_objs;
-  for (auto app : enabled_applications()) {
+  for (auto app : get_applications()) {
+    const Resource* res = app->cast<Resource>();
+    if (res != nullptr && res->is_disabled(*session)) {
+      continue;
+    }
     auto obj = app->config_object();  // Take a copy because we need
                                       // to call a non-const method!
     auto rels = relationships(configuration(), obj);
@@ -250,6 +254,14 @@ Session::managed_object_tags() const {
       result.insert(tags.begin(), tags.end());
     }
   }
+
+  for (auto seg : get_segments()) {
+    if (!seg->is_disabled(*session)) {
+      auto tags = seg->managed_object_tags(session);
+      result.insert(tags.begin(), tags.end());
+    }
+  }
+
   result.erase("");
   return result;
 }

--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -17,6 +17,7 @@
 #include "confmodel/DetectorToDaqConnection.hpp"
 #include "confmodel/DetectorStream.hpp"
 #include "confmodel/Jsonable.hpp"
+#include "confmodel/ManagedObject.hpp"
 #include "confmodel/OpMonURI.hpp"
 #include "confmodel/PhysicalHost.hpp"
 #include "confmodel/RCApplication.hpp"
@@ -203,6 +204,54 @@ Session::enabled_applications() const {
   return apps;
 }
 
+static std::set<std::string>
+relationships(conffwk::Configuration& confdb, ConfigObject& obj) {
+  std::set<std::string> result;
+  auto class_info = confdb.get_class_info(obj.class_name());
+  for (auto rel: class_info.p_relationships) {
+    if (rel.p_cardinality == cardinality_t::zero_or_one ||
+        rel.p_cardinality == cardinality_t::only_one) {
+      ConfigObject rel_obj;
+      obj.get(rel.p_name, rel_obj);
+      if (!rel_obj.is_null()) {
+        result.insert(rel_obj.UID());
+        auto rels = relationships(confdb, rel_obj);
+        result.insert(rels.begin(), rels.end());
+      }
+    }
+    else {
+      std::vector<ConfigObject> rel_vec;
+      obj.get(rel.p_name, rel_vec);
+      for (auto rel_obj: rel_vec) {
+        result.insert(rel_obj.UID());
+      }
+      for (auto relobj : rel_vec) {
+        auto rels = relationships(confdb, relobj);
+        result.insert(rels.begin(), rels.end());
+      }
+    }
+  } 
+  return result;
+}
+std::set<std::string>
+Session::managed_object_tags() const {
+  std::set<std::string> related_objs;
+  for (auto app : enabled_applications()) {
+    auto obj = app->config_object();  // Take a copy because we need
+                                      // to call a non-const method!
+    auto rels = relationships(configuration(), obj);
+    related_objs.insert(rels.begin(), rels.end());
+  }
+  std::set<std::string> result;
+  for (auto obj : related_objs) {
+    auto mobj = configuration().get<ManagedObject>(obj);
+    if (mobj != nullptr) {
+      auto tags = mobj->object_tags();
+      result.insert(tags.begin(), tags.end());
+    }
+  }
+  return result;
+}
 
 // ========================================================================
 

--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -237,6 +237,7 @@ std::set<std::string>
 Segment::managed_object_tags(const Session* session) const {
   std::set<std::string> related_objs;
   for (auto app : get_applications()) {
+    related_objs.insert(app->UID());
     const Resource* res = app->cast<Resource>();
     if (res != nullptr && res->is_disabled(*session)) {
       continue;

--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -250,6 +250,7 @@ Session::managed_object_tags() const {
       result.insert(tags.begin(), tags.end());
     }
   }
+  result.erase("");
   return result;
 }
 


### PR DESCRIPTION
# Description

In preparation for a resource manager prototype, declare a ManagedObject OKS class with a virtual method to return a set of tags which define the rsources to be managed. Also add a method to `Segment` to allow collecting all the tags from a Segment.

A python binding to the segment method allows the tags to be collected by drunc.
```
>>> import conffwk
>>> import confmodel_dal
>>> db = conffwk.Configuration("oksconflibs:../config/daqsystemtest/example-configs.data.xml")
>>> confmodel_dal.segment_get_managed_object_tags(db._obj, 'local-1x1-config')
{'APA1'}
>>> confmodel_dal.segment_get_managed_object_tags(db._obj, 'local-1x1-config', 'root-segment')
{'APA1'}
>>> confmodel_dal.segment_get_managed_object_tags(db._obj, 'local-1x1-config', 'df-segment')
set()
>>> confmodel_dal.segment_get_managed_object_tags(db._obj, 'local-1x1-config', 'ru-segment')
{'APA1'}
>>>
```

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

