### PR TITLE
Add code to track why a Resource is disabled

### DIFF
--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -108,7 +108,7 @@ namespace dunedaq::confmodel::python {
       if (component_ptr == nullptr) {
         throw (std::runtime_error(std::format("Component {} not found", component_id)));
       }
-      return component_ptr->m_disabled_reason;
+      return component_ptr->why_disabled();
     } else {
       return "not disabled";
     }

--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -99,6 +99,34 @@ namespace dunedaq::confmodel::python {
     return component_ptr->is_disabled(*session_ptr);
   }
 
+  std::string why_disabled(Configuration& db,
+                          const std::string& session_id,
+                          const std::string& component_id) {
+    if (component_disabled(db, session_id, component_id)) {
+      const dunedaq::confmodel::Resource* component_ptr =
+        db.get<dunedaq::confmodel::Resource>(component_id);
+      if (component_ptr == nullptr) {
+        throw (std::runtime_error(std::format("Component {} not found", component_id)));
+      }
+      return component_ptr->m_disabled_reason;
+    } else {
+      return "not disabled";
+    }
+  }
+
+  std::vector<std::string>
+  contained_components(Configuration& db,
+                       const std::string& set_id) {
+    std::vector<std::string> result;
+    const dunedaq::confmodel::ResourceSet* set_ptr = db.get<dunedaq::confmodel::ResourceSet>(set_id);
+    if (set_ptr == nullptr) {
+      return result;
+    }
+    for (auto res : set_ptr->contained_resources()) {
+      result.emplace_back(res->UID());
+    }
+    return result;
+  }
 
   std::vector<std::vector<ObjectLocator>> component_get_parents(Configuration& db,
                                                                 const std::string& session_id,
@@ -212,6 +240,9 @@ register_dal_methods(py::module& m)
   m.def("enable_component", &enable_component, "Enable a Resource-derived object (e.g. a Segment)");
 
   m.def("component_disabled", &component_disabled, "Determine if a Resource-derived object (e.g. a Segment) has been disabled");
+  m.def("why_disabled", &why_disabled, "Why is a Resource-derived object (e.g. a Segment) disabled");
+  m.def("contained_components", &contained_components, "Get list of components of  a ResourceSet object");
+
   m.def("component_get_parents", &component_get_parents, "Get the Resource-derived class instances of the parent(s) of the Resource-derived object in question");
   m.def("daqapp_get_used_resources", &daq_application_get_used_hostresources, "Get list of HostResources used by DAQApplication");
   m.def("daq_application_construct_commandline_parameters", &daq_application_construct_commandline_parameters, "Get a version of the command line agruments parsed");

--- a/schema/confmodel/dunedaq.schema.xml
+++ b/schema/confmodel/dunedaq.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="49" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260415T111439"/>
+<info name="" type="" num-of-items="49" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260720T111739"/>
 
  <class name="ActionPlan" description="A set of steps for an application to carry out a command">
   <attribute name="execution_policy" description="How the application should dispatch the command to modules matched by each step of the ActionPlan" type="enum" range="modules-in-parallel,modules-in-series" init-value="modules-in-parallel"/>
@@ -336,7 +336,13 @@
    <method-implementation language="c++" prototype="bool is_disabled(const dunedaq::confmodel::ResourceTree&amp; session) const" body=""/>
   </method>
   <method name="compute_disabled_state" description="Virtual method to be implemented by subclasses containing the logic to determine if this object should be considered disabled.">
-   <method-implementation language="c++" prototype="virtual bool compute_disabled_state(const std::set&lt;std::string&gt;&amp;) const" body="BEGIN_PUBLIC_SECTION&#xA;mutable std::string m_disabled_reason{&quot;&quot;};&#xA;END_PUBLIC_SECTION&#xA;"/>
+   <method-implementation language="c++" prototype="virtual bool compute_disabled_state(const std::set&lt;std::string&gt;&amp;) const" body=""/>
+  </method>
+  <method name="why_disabled" description="Report reason that this Resource is disabled">
+   <method-implementation language="c++" prototype="std::string why_disabled() const" body="BEGIN_PRIVATE_SECTION&#xA;mutable std::string m_disabled_reason{&quot;&quot;};&#xA;END_PRIVATE_SECTION&#xA;&#xA;{&#xA;return m_disabled_reason;&#xA;}"/>
+  </method>
+  <method name="set_disabled_reason" description="Function to set the reason that this Resource is disabled. Does not change the disabled state of the Resource">
+   <method-implementation language="c++" prototype="void set_disabled_reason(const std::string&amp; reason) const" body="m_disabled_reason = reason;"/>
   </method>
  </class>
 
@@ -350,14 +356,14 @@
  <class name="ResourceSetDisableAND" description="Abstract base class for a resource set that determines it&apos;s disabled state by ANDing all its contained resources." is-abstract="yes">
   <superclass name="ResourceSet"/>
   <method name="compute_disabled_state" description="Method that ANDs all resources to determine disabled state.">
-   <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body="  if (disabled.contains(UID())) {&#xA;    return true;&#xA;  }&#xA;  for (auto res: contained_resources()) {&#xA;     if (!res-&gt;compute_disabled_state(disabled)) {&#xA;        return false;&#xA;    }&#xA;  }&#xA;  m_disabled_reason=&quot;all contained components disabled&quot;;&#xA;  return true;&#xA;  "/>
+   <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body="  if (disabled.contains(UID())) {&#xA;    return true;&#xA;  }&#xA;  for (auto res: contained_resources()) {&#xA;     if (!res-&gt;compute_disabled_state(disabled)) {&#xA;        return false;&#xA;    }&#xA;  }&#xA;  set_disabled_reason(&quot;all contained components disabled&quot;);&#xA;  return true;&#xA;  "/>
   </method>
  </class>
 
  <class name="ResourceSetDisableOR" is-abstract="yes">
   <superclass name="ResourceSet"/>
   <method name="compute_disabled_state" description="Method that ORs the disabled state of its contained resources to determine the state of the set">
-   <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body="  if (disabled.contains(UID())) {&#xA;    return true;&#xA;  }&#xA;  for (auto res: contained_resources()) {&#xA;     if (res-&gt;compute_disabled_state(disabled)) {&#xA;        m_disabled_reason = &quot;child &quot; + res-&gt;UID() + &quot; disabled, &quot; + res-&gt;m_disabled_reason;&#xA;        return true;&#xA;    }&#xA;  }&#xA;  return false;&#xA;  "/>
+   <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body="  if (disabled.contains(UID())) {&#xA;    return true;&#xA;  }&#xA;  for (auto res: contained_resources()) {&#xA;     if (res-&gt;compute_disabled_state(disabled)) {&#xA;        set_disabled_reason(&quot;child &quot; + res-&gt;UID() + &quot; disabled, &quot; + res-&gt;why_disabled());&#xA;        return true;&#xA;    }&#xA;  }&#xA;  return false;&#xA;  "/>
   </method>
  </class>
 

--- a/schema/confmodel/dunedaq.schema.xml
+++ b/schema/confmodel/dunedaq.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="49" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260218T122834"/>
+<info name="" type="" num-of-items="49" oks-format="schema" oks-version="862f2957270" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260415T111439"/>
 
  <class name="ActionPlan" description="A set of steps for an application to carry out a command">
   <attribute name="execution_policy" description="How the application should dispatch the command to modules matched by each step of the ActionPlan" type="enum" range="modules-in-parallel,modules-in-series" init-value="modules-in-parallel"/>
@@ -336,7 +336,7 @@
    <method-implementation language="c++" prototype="bool is_disabled(const dunedaq::confmodel::ResourceTree&amp; session) const" body=""/>
   </method>
   <method name="compute_disabled_state" description="Virtual method to be implemented by subclasses containing the logic to determine if this object should be considered disabled.">
-   <method-implementation language="c++" prototype="virtual bool compute_disabled_state(const std::set&lt;std::string&gt;&amp;) const" body=""/>
+   <method-implementation language="c++" prototype="virtual bool compute_disabled_state(const std::set&lt;std::string&gt;&amp;) const" body="BEGIN_PUBLIC_SECTION&#xA;mutable std::string m_disabled_reason{&quot;&quot;};&#xA;END_PUBLIC_SECTION&#xA;"/>
   </method>
  </class>
 
@@ -350,14 +350,14 @@
  <class name="ResourceSetDisableAND" description="Abstract base class for a resource set that determines it&apos;s disabled state by ANDing all its contained resources." is-abstract="yes">
   <superclass name="ResourceSet"/>
   <method name="compute_disabled_state" description="Method that ANDs all resources to determine disabled state.">
-   <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body="  if (disabled.contains(UID())) {&#xA;    return true;&#xA;  }&#xA;  for (auto res: contained_resources()) {&#xA;     if (!res-&gt;compute_disabled_state(disabled)) {&#xA;        return false;&#xA;    }&#xA;  }&#xA;  return true;&#xA;  "/>
+   <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body="  if (disabled.contains(UID())) {&#xA;    return true;&#xA;  }&#xA;  for (auto res: contained_resources()) {&#xA;     if (!res-&gt;compute_disabled_state(disabled)) {&#xA;        return false;&#xA;    }&#xA;  }&#xA;  m_disabled_reason=&quot;all contained components disabled&quot;;&#xA;  return true;&#xA;  "/>
   </method>
  </class>
 
  <class name="ResourceSetDisableOR" is-abstract="yes">
   <superclass name="ResourceSet"/>
   <method name="compute_disabled_state" description="Method that ORs the disabled state of its contained resources to determine the state of the set">
-   <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body="  if (disabled.contains(UID())) {&#xA;    return true;&#xA;  }&#xA;  for (auto res: contained_resources()) {&#xA;     if (res-&gt;compute_disabled_state(disabled)) {&#xA;        return true;&#xA;    }&#xA;  }&#xA;  return false;&#xA;  "/>
+   <method-implementation language="c++" prototype="bool compute_disabled_state(const std::set&lt;std::string&gt;&amp; disabled) const final" body="  if (disabled.contains(UID())) {&#xA;    return true;&#xA;  }&#xA;  for (auto res: contained_resources()) {&#xA;     if (res-&gt;compute_disabled_state(disabled)) {&#xA;        m_disabled_reason = &quot;child &quot; + res-&gt;UID() + &quot; disabled, &quot; + res-&gt;m_disabled_reason;&#xA;        return true;&#xA;    }&#xA;  }&#xA;  return false;&#xA;  "/>
   </method>
  </class>
 

--- a/src/DisabledResources.cpp
+++ b/src/DisabledResources.cpp
@@ -43,6 +43,7 @@ void DisabledResources::update(const ResourceSet* root,
 
   for (auto & comp : initial_list) {
     disable(*comp);
+    comp->m_disabled_reason = "disabled in initial list";
     TLOG_DEBUG(6) << comp->UID() << " is disabled in session";
     if (const ResourceSet * rs = comp->cast<ResourceSet>()) {
       disable_children(*rs);
@@ -56,6 +57,9 @@ void DisabledResources::update(const ResourceSet* root,
     for (const auto& res_set : resource_sets) {
       if (is_enabled(res_set)) {
         if (res_set->compute_disabled_state(m_disabled)) {
+          if (res_set->m_disabled_reason.empty()) {
+            res_set->m_disabled_reason = "state of contained components";
+          }
           TLOG_DEBUG(6) <<  "disable custom resource-set- " << res_set->UID() << " because children are disabled" ;
           disable(*res_set);
           disable_children(*res_set);
@@ -102,6 +106,10 @@ DisabledResources::disable_children(const ResourceSet& rs)
 {
   TLOG_DEBUG(6) << "Disabling children of " << rs.UID();
   for (auto & res : rs.contained_resources()) {
+    if (res->m_disabled_reason.empty()) {
+      res->m_disabled_reason = "child of disabled object " + rs.UID() + ", "
+        + rs.m_disabled_reason;
+    }
     TLOG_DEBUG(6) << "Disabling child " << res->UID();
     disable(*res);
     if (const auto * rs2 = res->cast<ResourceSet>()) {

--- a/src/DisabledResources.cpp
+++ b/src/DisabledResources.cpp
@@ -40,7 +40,7 @@ void DisabledResources::update(const ResourceSet* root,
 
   for (auto & comp : initial_list) {
     disable(*comp);
-    comp->m_disabled_reason = "disabled in initial list";
+    comp->set_disabled_reason("disabled in initial list");
     TLOG_DEBUG(6) << comp->UID() << " is disabled in session";
     if (const ResourceSet * rs = comp->cast<ResourceSet>()) {
       disable_children(*rs);
@@ -54,8 +54,8 @@ void DisabledResources::update(const ResourceSet* root,
     for (const auto& res_set : resource_sets) {
       if (is_enabled(res_set)) {
         if (res_set->compute_disabled_state(m_disabled)) {
-          if (res_set->m_disabled_reason.empty()) {
-            res_set->m_disabled_reason = "state of contained components";
+          if (res_set->why_disabled().empty()) {
+            res_set->set_disabled_reason("state of contained components");
           }
           TLOG_DEBUG(6) <<  "disable custom resource-set- " << res_set->UID() << " because children are disabled" ;
           disable(*res_set);
@@ -113,9 +113,9 @@ DisabledResources::disable_children(const ResourceSet& rs)
 {
   TLOG_DEBUG(6) << "Disabling children of " << rs.UID();
   for (auto & res : rs.contained_resources()) {
-    if (res->m_disabled_reason.empty()) {
-      res->m_disabled_reason = "child of disabled object " + rs.UID() + ", "
-        + rs.m_disabled_reason;
+    if (res->why_disabled().empty()) {
+      res->set_disabled_reason("child of disabled object " + rs.UID() + ", "
+                               + rs.why_disabled());
     }
     TLOG_DEBUG(6) << "Disabling child " << res->UID();
     disable(*res);

--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -461,7 +461,7 @@ DetectorToDaqConnection::compute_disabled_state(const std::set<std::string>& dis
 
 
   if (send_disabled) {
-    m_disabled_reason = "all senders disabled";
+    set_disabled_reason("all senders disabled");
   }
 
   bool rec_disabled = false;
@@ -470,12 +470,12 @@ DetectorToDaqConnection::compute_disabled_state(const std::set<std::string>& dis
     rec_disabled = receiver()->compute_disabled_state(disabled_resources);
     if (rec_disabled) {
       std::string recv_reason = "receiver " + receiver()->UID() +
-        " disabled, " + receiver()->m_disabled_reason;
+        " disabled, " + receiver()->why_disabled();
       if (send_disabled) {
-        m_disabled_reason += " and " + recv_reason;
+        set_disabled_reason("all senders disabled and " + recv_reason);
       }
       else {
-        m_disabled_reason = recv_reason;
+        set_disabled_reason(recv_reason);
       }
     }
   }
@@ -516,7 +516,7 @@ Segment::compute_disabled_state(const std::set<std::string>& disabled) const {
       return false;
     }
   }
-  m_disabled_reason = "all contained segments/applications disabled";
+  set_disabled_reason("all contained segments/applications disabled");
   return true;
 }
 

--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -456,10 +456,21 @@ DetectorToDaqConnection::compute_disabled_state(const std::set<std::string>& dis
   }
   TLOG_DBG(6) << "receiver disabled=" << receiver()->compute_disabled_state(disabled_resources)
               << " senders disabled=" << send_disabled;
-  if (receiver()->compute_disabled_state(disabled_resources) || send_disabled) {
-    return true;
+  if (send_disabled) {
+    m_disabled_reason = "all senders disabled";
   }
-  return false;
+  bool rec_disabled = receiver()->compute_disabled_state(disabled_resources);
+  if (rec_disabled) {
+    std::string recv_reason = "receiver " + receiver()->UID() +
+      " disabled, " + receiver()->m_disabled_reason;
+    if (send_disabled) {
+      m_disabled_reason += " and " + recv_reason;
+    }
+    else {
+      m_disabled_reason = recv_reason;
+    }
+  }
+  return rec_disabled || send_disabled;
 }
 
 std::vector<const Resource*>
@@ -496,6 +507,7 @@ Segment::compute_disabled_state(const std::set<std::string>& disabled) const {
       return false;
     }
   }
+  m_disabled_reason = "all contained segments/applications disabled";
   return true;
 }
 


### PR DESCRIPTION
# Description

It is sometimes difficult to know why a Resource is disabled. This update adds a string member to the Resource class to store a reason and code to the DisabledResources class and individual ResourceSet implementations to store the reason.

Python bindings are provided to query why a Resource is disabled and to list all the Resources contained in a ResourceSet

```
>>> import conffwk
>>> import confmodel_dal
>>> db = conffwk.Configuration("oksconflibs:sessions/tde-testcrate.data.xml")
>>> confmodel_dal.why_disabled(db._obj,'tde-testcrate-session','runp02srv004tde-testcrate')
'all contained components disabled'
>>> confmodel_dal.why_disabled(db._obj,'tde-testcrate-session','tde-testcrate-segment')
'all contained segments/applications disabled'
>>> confmodel_dal.why_disabled(db._obj,'tde-testcrate-session','DetStream-302')
'child of disabled object dds-tde-amc-crate0-slot1, child of disabled object tde-connections-test-crate, receiver dpdk-np02srv004-receiver-3-tde disabled, child of disabled object tde-connections-crate-3-4-5-8-9, disabled in initial list'
```

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

