### PR TITLE
accounting for empty receiver

### DIFF
--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -461,11 +461,9 @@ DetectorToDaqConnection::compute_disabled_state(const std::set<std::string>& dis
   auto rec = receiver();
   if ( ! rec )
     return send_disabled;
-  
-  if (rec->compute_disabled_state(disabled_resources) || send_disabled) {
-    return true;
-  }
-  return false;
+
+  return (rec->compute_disabled_state(disabled_resources) || send_disabled) ;
+
 }
 
 std::vector<const Resource*>

--- a/src/dalMethods.cpp
+++ b/src/dalMethods.cpp
@@ -437,7 +437,9 @@ std::vector<const Resource*> DetDataSender::contained_resources() const {
 
 std::vector<const Resource*> DetectorToDaqConnection::contained_resources() const {
   auto res = to_resources(senders());
-  res.push_back(receiver());
+  auto rec = receiver();
+  if (rec) 
+    res.push_back(rec);
   return res;
 }
 
@@ -456,7 +458,11 @@ DetectorToDaqConnection::compute_disabled_state(const std::set<std::string>& dis
   }
   TLOG_DBG(6) << "receiver disabled=" << receiver()->compute_disabled_state(disabled_resources)
               << " senders disabled=" << send_disabled;
-  if (receiver()->compute_disabled_state(disabled_resources) || send_disabled) {
+  auto rec = receiver();
+  if ( ! rec )
+    return send_disabled;
+  
+  if (rec->compute_disabled_state(disabled_resources) || send_disabled) {
     return true;
   }
   return false;


### PR DESCRIPTION
# Description

See https://github.com/DUNE-DAQ/dfmodules/issues/492 

run dfmodules unittests. Without this change the HDF5FileWrite test fails due to seg fault.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

